### PR TITLE
Import libraries to remove errors when using SPM

### DIFF
--- a/Sources/Helpers/Extensions/UINavigationController+.swift
+++ b/Sources/Helpers/Extensions/UINavigationController+.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import UIKit
 
 extension UINavigationController {
     func setBackgroundColor(color: UIColor = .black) {

--- a/Sources/Helpers/Managers/WindowManager.swift
+++ b/Sources/Helpers/Managers/WindowManager.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import UIKit
 
 struct WindowManager {
     static var rootNavigation: UINavigationController? {


### PR DESCRIPTION
No SPM os arquivos são usados conforme são escritos, portanto, os imports são obrigatórios em todos os arquivos, diferentemente do uso com CocoaPods.