### PR TITLE
Remove public extension

### DIFF
--- a/DebugSwift/Sources/Helpers/Tools/UserDefaultsAccess.swift
+++ b/DebugSwift/Sources/Helpers/Tools/UserDefaultsAccess.swift
@@ -13,17 +13,17 @@ public protocol UserDefaultsService {
 }
 
 extension UserDefaults {
-    public enum Key: String {
+    enum Key: String {
         case debugger
     }
 }
 
-@propertyWrapper public struct UserDefaultAccess<T: Codable> {
+@propertyWrapper struct UserDefaultAccess<T: Codable> {
     let key: String
     let defaultValue: T
     let userDefaults: UserDefaultsService
 
-    public init(
+    init(
         key: UserDefaults.Key,
         defaultValue: T,
         userDefaults: UserDefaultsService = UserDefaults.standard

--- a/DebugSwift/Sources/Settings/DebugSwift.swift
+++ b/DebugSwift/Sources/Settings/DebugSwift.swift
@@ -54,7 +54,7 @@ extension DebugSwift {
         public static var onlyLogs = [String]()
     }
 
-    public enum Debugger {
+    enum Debugger {
         @UserDefaultAccess(key: .debugger, defaultValue: true)
         public static var enable: Bool
     }


### PR DESCRIPTION
Quando usamos extensions públicas corremos o risco de declarar objetos com o mesmo nome já existente.

No meu caso, possuo um enum chamado Key em uma extension interna para tratar os meus tokens de valores armazenados usando UserDefaults e isso causou um erro de ambiguidade.

Aconselharia não usar extensions públicas para esses casos para não dar erros de ambiguidade.