### PR TITLE
[Geral] Ajuste no botão fechar em devices com sistema operacional mais antigos

### DIFF
--- a/DebugSwift/Sources/Base/TabBarController.swift
+++ b/DebugSwift/Sources/Base/TabBarController.swift
@@ -52,7 +52,7 @@ class TabBarController: UITabBarController {
         navigationItem.hidesBackButton = true
         addRightBarButton(
             image: .named(
-                "arrow.up.right.and.arrow.down.left",
+                getTabBarImageName(),
                 default: "close".localized()
             ),
             tintColor: .white
@@ -63,5 +63,18 @@ class TabBarController: UITabBarController {
 
     @objc private func closeButtonTapped() {
         WindowManager.removeDebugger()
+    }
+}
+
+// MARK: - Helper
+
+extension TabBarController {
+    /// Get `SF Symbols` image name for `TabBar` based on `iOS` version
+    /// - Returns: image name
+    private func getTabBarImageName() -> String {
+        if #available(iOS 17.0, *) {
+            return "arrow.up.right.and.arrow.down.left"
+        }
+        return "xmark.circle"
     }
 }


### PR DESCRIPTION
# Descrição
Em dispositivos cujo sistema operacional seja menor que 17.0, não é possível atribuir a imagem `"arrow.up.right.and.arrow.down.left"` e, como resultado, o botão fechar/minimizar fica invisível (embora funcional).
Este PR adiciona uma tratativa para lidar com devices iOS < 17, atribuindo uma imagem compatível com S.Os mais antigos.